### PR TITLE
Added 20s stop grace period for Cacti and db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: "mcncclovett/cacti"
     container_name: cacti
     restart: unless-stopped
+    stop_grace_period: 20s
     ports:
       - "8080:80"
       - "8443:443"
@@ -25,6 +26,7 @@ services:
     image: "percona:5.7.14"
     container_name: db
     restart: unless-stopped
+    stop_grace_period: 20s
     ports:
       - "3306:3306"
     command:


### PR DESCRIPTION
The containers were taking longer than the default 10s to stop, which caused docker to send a SIGKILL. This was causing Cacti to not restart.